### PR TITLE
Add cpu credits and change terraform_image build number

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This module is tailered very specific for Skyscrapers environments
   * [`ami`]: String(required): AMI to be used for the proxy instances.
   * [`key_name`]: String(required): ID of the SSH key to use for the proxy instances.
   * [`instance_type`] String(optional, default "t2.small"): The instance type to launch for the proxy hosts.
+  * [`cpu_credits`] String(optional, default "standard"): The type of cpu credits to use
 
 ## Output
 
@@ -37,6 +38,7 @@ module "hacaddy" {
   sg_all_id     = "${module.securitygroups.sg_all_id}"
   ami           = "ami-971238f1"
   key_name      = "philip"
-  instance_type = "t2.small"
+  instance_type = "t3.small"
+  cpu_credits   = "unlimited"
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "hacaddy_instance" {
-  source         = "github.com/skyscrapers/terraform-instances//instance?ref=2.3.2"
+  source         = "github.com/skyscrapers/terraform-instances//instance?ref=2.3.6"
   project        = "${var.project}"
   environment    = "${var.environment}"
   name           = "${var.proxyname}"
@@ -11,6 +11,7 @@ module "hacaddy_instance" {
   sgs            = ["${var.sg_all_id}", "${aws_security_group.sg_hacaddy.id}"]
   public_ip      = true
   user_data      = ["${module.userdata.user_datas[0]}", "${module.userdata.user_datas[1]}"]
+  cpu_credits    = "${var.cpu_credits}"
 }
 
 module "userdata" {
@@ -35,7 +36,7 @@ resource "aws_efs_mount_target" "hacaddy_efs_target" {
   count           = "${var.subnet_count}"
   file_system_id  = "${aws_efs_file_system.hacaddy_efs.id}"
   subnet_id       = "${var.subnet_ids[count.index]}"
-  security_groups = [ "${aws_security_group.sg_hacaddy.id}" ]
+  security_groups = ["${aws_security_group.sg_hacaddy.id}"]
 }
 
 resource "aws_eip" "hacaddy_eip" {
@@ -49,8 +50,8 @@ resource "aws_eip" "hacaddy_eip" {
 }
 
 resource "aws_iam_role_policy" "hacaddy_policy" {
-  name   = "policy_${var.proxyname}_${var.project}_${var.environment}"
-  role   = "${module.hacaddy_instance.role_id}"
+  name = "policy_${var.proxyname}_${var.project}_${var.environment}"
+  role = "${module.hacaddy_instance.role_id}"
 
   policy = <<EOF
 {
@@ -83,7 +84,6 @@ resource "aws_security_group" "sg_hacaddy" {
     Project     = "${var.project}"
   }
 }
-
 
 ## INGRESS
 
@@ -131,7 +131,6 @@ resource "aws_security_group_rule" "hacaddy_efs_ingress" {
   security_group_id        = "${aws_security_group.sg_hacaddy.id}"
   source_security_group_id = "${aws_security_group.sg_hacaddy.id}"
 }
-
 
 ## EGRESS
 

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,9 @@ variable "instance_type" {
   description = "The instance type to launch for the proxy hosts"
   default     = "t2.micro"
 }
+
+variable "cpu_credits" {
+  type        = "string"
+  description = "The type of cpu credits to use"
+  default     = "standard"
+}


### PR DESCRIPTION
This build enables the usage of cpu_credits, it relies on a new build of the terraform-instance module